### PR TITLE
Fix TimeoutError warning message

### DIFF
--- a/client_code/helper.py
+++ b/client_code/helper.py
@@ -179,7 +179,7 @@ def _robust_server_call(n, call_fn, fn_name, *args, **kwargs):
       return call_fn(fn_name, *args, **kwargs)
     except anvil.server.TimeoutError:
       from . import helper as h
-      warning("Re-trying {fn_name} server call due to TimeoutError")
+      warning(f"Re-trying {fn_name} server call due to TimeoutError")
       return _robust_server_call(n-1, call_fn, fn_name, *args, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- fix string interpolation for TimeoutError retry log

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anvil')*
- `pip install anvil-uplink` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_68640a1c6e6c832299c1de80f7fda8b6